### PR TITLE
Adjust replace, modify extract header

### DIFF
--- a/atomic-extract.ipynb
+++ b/atomic-extract.ipynb
@@ -1276,7 +1276,7 @@
     "    if (not isinstance(row.head, str)) or (not isinstance(row.tail, str)):\n",
     "        continue\n",
     "\n",
-    "    col1 = nlp(row.head)\n",
+    "    col1 = nlp(row.head.replace('PersonX','Person'))\n",
     "    col2 = nlp(row.tail)\n",
     "\n",
     "    tmp1 = set([token.lemma_ for token in col1 if token.pos_ == 'VERB'])\n",
@@ -1310,7 +1310,7 @@
     "    if (not isinstance(row.head, str)) or (not isinstance(row.tail, str)):\n",
     "        continue\n",
     "    \n",
-    "    col1 = nlp(row.head)\n",
+    "    col1 = nlp(row.head.replace('PersonX','Person'))\n",
     "    col2 = nlp(row.tail)\n",
     "\n",
     "    tmp1 = set([token.lemma_ for token in col1 if token.pos_ == 'VERB'])\n",
@@ -1342,7 +1342,7 @@
     "    if (not isinstance(row.head, str)) or (not isinstance(row.tail, str)):\n",
     "        continue\n",
     "    \n",
-    "    col1 = nlp(row.head)\n",
+    "    col1 = nlp(row.head.replace('PersonX','Person'))\n",
     "    col2 = nlp(row.tail)\n",
     "\n",
     "    tmp1 = set([token.lemma_ for token in col1 if token.pos_ == 'VERB'])\n",
@@ -1759,7 +1759,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "atomic_train[atomic_train['match'] == True][['head', 'relation', 'tail']].to_csv(\n",
+    "atomic_train[atomic_train['match'] == True][['head', 'relation', 'tail','verbs_head','verbs_tail']].to_csv(\n",
     "    \"./output/atomic_train_match.tsv\", sep='\\t', index=False, header=False)"
    ]
   },
@@ -1769,7 +1769,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "atomic_dev[atomic_dev['match'] == True][['head', 'relation', 'tail']].to_csv(\n",
+    "atomic_dev[atomic_dev['match'] == True][['head', 'relation', 'tail','verbs_head','verbs_tail']].to_csv(\n",
     "    \"./output/atomic_dev_match.tsv\", sep='\\t', index=False, header=False)"
    ]
   },
@@ -1779,7 +1779,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "atomic_test[atomic_test['match'] == True][['head', 'relation', 'tail']].to_csv(\n",
+    "atomic_test[atomic_test['match'] == True][['head', 'relation', 'tail','verbs_head','verbs_tail']].to_csv(\n",
     "    \"./output/atomic_test_match.tsv\", sep='\\t', index=False, header=False)"
    ]
   },


### PR DESCRIPTION
ATOMIC-2020 header를 토큰화할 때, PersonX를 Person으로 변환하여 사용하도록 변경.
ATOMIC-Extract 생성 시 verbs_head와 verbs_tail도 저장하게 변경
(추후 Extract에서 색인 가능하게 하기 위함)